### PR TITLE
Fix: restore pygame audio backend (volume control and playback dead without VLC)

### DIFF
--- a/HomeAssistantWindows.spec
+++ b/HomeAssistantWindows.spec
@@ -3,7 +3,7 @@ from PyInstaller.utils.hooks import collect_all
 
 datas = [('src', 'src')]
 binaries = []
-hiddenimports = ['windows_toasts', 'pycaw', 'comtypes', 'pystray', 'win10toast', 'src.platforms.windows', 'aioesphomeapi', 'sounddevice', 'numpy', 'psutil', 'pymicro_wakeword', 'pyopen_wakeword', 'webrtcvad', 'zeroconf', 'PIL', 'src.i18n', 'src.core.mdns_discovery', 'src.core.esphome_protocol', 'src.ui.system_tray_icon', 'src.voice.audio_recorder', 'src.voice.mpv_player', 'src.voice.wake_word', 'src.voice.vad', 'src.commands.command_executor', 'src.commands.system_commands', 'src.commands.media_commands', 'src.commands.audio_commands', 'src.sensors.windows_monitor', 'src.notify.announcement', 'src.notify.toast_notification', 'src.notify.service_entity', 'src.ui.main_window', 'src.autostart', 'src.platforms', 'src.platforms.base']
+hiddenimports = ['windows_toasts', 'pycaw', 'comtypes', 'pystray', 'win10toast', 'src.platforms.windows', 'aioesphomeapi', 'sounddevice', 'numpy', 'psutil', 'pymicro_wakeword', 'pyopen_wakeword', 'webrtcvad', 'zeroconf', 'PIL', 'pygame', 'pygame.mixer', 'pygame.mixer_music', 'src.i18n', 'src.core.mdns_discovery', 'src.core.esphome_protocol', 'src.ui.system_tray_icon', 'src.voice.audio_recorder', 'src.voice.mpv_player', 'src.voice.wake_word', 'src.voice.vad', 'src.commands.command_executor', 'src.commands.system_commands', 'src.commands.media_commands', 'src.commands.audio_commands', 'src.sensors.windows_monitor', 'src.notify.announcement', 'src.notify.toast_notification', 'src.notify.service_entity', 'src.ui.main_window', 'src.autostart', 'src.platforms', 'src.platforms.base']
 tmp_ret = collect_all('aioesphomeapi')
 datas += tmp_ret[0]; binaries += tmp_ret[1]; hiddenimports += tmp_ret[2]
 tmp_ret = collect_all('pycaw')
@@ -13,6 +13,8 @@ datas += tmp_ret[0]; binaries += tmp_ret[1]; hiddenimports += tmp_ret[2]
 tmp_ret = collect_all('pymicro_wakeword')
 datas += tmp_ret[0]; binaries += tmp_ret[1]; hiddenimports += tmp_ret[2]
 tmp_ret = collect_all('pyopen_wakeword')
+datas += tmp_ret[0]; binaries += tmp_ret[1]; hiddenimports += tmp_ret[2]
+tmp_ret = collect_all('pygame')
 datas += tmp_ret[0]; binaries += tmp_ret[1]; hiddenimports += tmp_ret[2]
 
 

--- a/HomeAssistantWindows_dir.spec
+++ b/HomeAssistantWindows_dir.spec
@@ -12,6 +12,7 @@ datas += collect_all('comtypes')[0]
 datas += collect_data_files('pymicro_wakeword', include_py_files=False)
 datas += collect_data_files('pyopen_wakeword', include_py_files=False)
 datas += collect_data_files('sounddevice', include_py_files=False)
+datas += collect_all('pygame')[0]
 datas += collect_data_files('webrtcvad', include_py_files=False)
 datas += collect_data_files('zeroconf', include_py_files=False)
 datas += collect_data_files('ifaddr', include_py_files=False)
@@ -35,6 +36,7 @@ binaries += collect_all('comtypes')[1]
 binaries += collect_dynamic_libs('pymicro_wakeword')
 binaries += collect_dynamic_libs('pyopen_wakeword')
 binaries += collect_dynamic_libs('sounddevice')
+binaries += collect_all('pygame')[1]
 binaries += collect_dynamic_libs('webrtcvad')
 binaries += collect_dynamic_libs('zeroconf')
 binaries += collect_dynamic_libs('ifaddr')
@@ -59,6 +61,9 @@ hiddenimports = [
     'PIL',
     'pystray',
     'windows_toasts',
+    'pygame',
+    'pygame.mixer',
+    'pygame.mixer_music',
     # src modules
     'src.i18n',
     'src.core.mdns_discovery',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "aiohttp>=3.8.0",
     "sounddevice>=0.5.0",
     "numpy>=1.24.0",
+    "pygame>=2.5.0",
     "python-vlc>=3.0.0",
     "pymicro-wakeword>=2.0.0",
     "pyopen-wakeword>=1.0.0",

--- a/requirements-windows.txt
+++ b/requirements-windows.txt
@@ -6,6 +6,7 @@ aioesphomeapi>=45.7.0
 aiohttp>=3.8.0
 sounddevice>=0.5.0
 numpy>=1.24.0
+pygame>=2.5.0
 python-vlc>=3.0.0
 pymicro-wakeword>=2.0.0
 pyopen-wakeword>=1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ aioesphomeapi>=45.7.0
 aiohttp>=3.8.0
 sounddevice>=0.5.0
 numpy>=1.24.0
+pygame>=2.5.0
 python-vlc>=3.0.0
 pymicro-wakeword>=2.0.0
 pyopen-wakeword>=1.0.0

--- a/setup.py
+++ b/setup.py
@@ -107,6 +107,9 @@ def build_exe():
         "--hidden-import=webrtcvad",
         "--hidden-import=zeroconf",
         "--hidden-import=PIL",
+        "--hidden-import=pygame",
+        "--hidden-import=pygame.mixer",
+        "--hidden-import=pygame.mixer_music",
         # src module hidden imports (important!)
         "--hidden-import=src.i18n",
         "--hidden-import=src.core.mdns_discovery",
@@ -136,6 +139,7 @@ def build_exe():
         "--collect-all=comtypes",
         "--collect-all=pymicro_wakeword",  # Include tensorflowlite_c.dll
         "--collect-all=pyopen_wakeword",
+        "--collect-all=pygame",  # SDL2_mixer.dll etc - audio playback/volume backend
         # Add src directory to Python path
         "--add-data=src;src" if CURRENT_PLATFORM == "Windows" else "--add-data=src:src",
         # Exclude unnecessary modules (reduce size)


### PR DESCRIPTION
## Problem

On 0.6.0, the Home Assistant `media_player` volume slider has no effect and all audio playback is silent — TTS, wake word chime and timer sounds.

`9c345cb` removed pygame to shrink the EXE (`移除 pygame，音频播放仅依赖 VLC`). But `python-vlc` ships **bindings only** — `libvlc.dll` is not bundled, and VLC is an optional user install documented in the README.

So on any machine without VLC, `AudioPlayer.__init__` ends up with `_vlc_available = False` **and** `_pygame_available = False` — no audio backend at all:

- `set_volume()` (`src/core/models.py:550`) matches neither the VLC branch nor the pygame branch and silently returns, so the volume slider does nothing
- every `play()` fails

From a 0.6.0 install with no VLC present:

```
ERROR - src.core.models - pygame playback error: module 'pygame' has no attribute 'mixer'
INFO  - src.core.esphome_protocol - Playing TTS: http://.../api/tts_proxy/....mp3
ERROR - src.core.models - pygame playback error: module 'pygame' has no attribute 'mixer'
```

(`AttributeError` rather than `ImportError` because in-place upgrades leave the previous version's `_internal/pygame/*.pyd` in place. With pygame's `__init__.py` gone from the new PYZ, Python imports that leftover directory as an empty namespace package.)

## Fix

Restore `pygame>=2.5.0` in `requirements.txt`, `requirements-windows.txt` and `pyproject.toml`, and make sure PyInstaller actually bundles it:

- **`setup.py`** — `--collect-all=pygame` plus `pygame` / `pygame.mixer` / `pygame.mixer_music` hidden imports. `setup.py --build` passes CLI args and *regenerates* `HomeAssistantWindows.spec`, so editing the spec alone does not survive a build.
- **`HomeAssistantWindows_dir.spec`** — it only had `collect_submodules('pygame')`, which returns an empty list when pygame isn't installed. Added `collect_all` datas and binaries so `SDL2_mixer.dll` and `mixer.cp312-win_amd64.pyd` land in `_internal`.

pygame also covers the `.flac` assets in `src/sounds/`, which `winsound` (the current fallback in `src/voice/mpv_player.py`) cannot decode.

## Verification

Built both targets locally on Windows 11 / Python 3.12.10 / pygame 2.6.1:

- `SDL2_mixer.dll`, `mixer.cp312-win_amd64.pyd` and `pygame/__init__.py` all present in `dist/HomeAssistantWindows/_internal/`
- ran the frozen dir build: clean startup, no `pygame not available` warning
- `AudioPlayer.set_volume(60)` followed by `play('src/sounds/wake_word_triggered.flac')` completes and fires its `done_callback`

## Cost

Single-file EXE grows from ~57MB to ~62MB.

If keeping 57MB matters more, the alternative is a ctypes MCI (`winmm.dll`) backend — no dependency, supports MP3/WAV plus volume/pause/stop — but MCI cannot decode FLAC, so the two `.flac` sound assets would need converting to WAV. Happy to send that version instead.
