### PR TITLE
Add microphone selection to the tray menu

### DIFF
--- a/src/core/esphome_protocol.py
+++ b/src/core/esphome_protocol.py
@@ -93,8 +93,6 @@ class ESPHomeProtocol(asyncio.Protocol):
         self._is_playing_tts = False  # Flag to pause wake word detection during TTS playback
         self._volume_ducking_enabled = False  # User preference: do not lower global system volume
 
-        # Audio recorder (lazy load)
-        self._audio_recorder = None
         self._audio_streaming_task: Optional[asyncio.Task] = None
         self._event_loop: Optional[asyncio.AbstractEventLoop] = None
 
@@ -552,15 +550,6 @@ class ESPHomeProtocol(asyncio.Protocol):
         self.state.tts_player.play(url, done_callback=on_done)
 
     # ========== Audio Control ==========
-
-    def _get_audio_recorder(self):
-        """Get or create audio recorder"""
-        if self._audio_recorder is None:
-            from src.voice.audio_recorder import AudioRecorder
-
-            self._audio_recorder = AudioRecorder()
-            logger.debug("🎤 Audio recorder initialized")
-        return self._audio_recorder
 
     def _start_audio_streaming(self) -> None:
         """Start audio streaming (audio is handled by main program's recorder)"""

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -195,6 +195,7 @@ class Preferences:
     thinking_sound: int = 0
     volume: Optional[float] = None
     voice_input_hotkey: str = ""
+    mic_device: str = ""  # microphone name, "" = system default
 
 
 class WindowsVolumeController:
@@ -345,6 +346,12 @@ class AudioPlayer:
                 logger.debug("Using pygame for audio (no streaming)")
         except Exception as e:
             logger.warning(f"pygame not available: {e}")
+
+        if not (self._vlc_available or self._pygame_available):
+            logger.error(
+                "No audio backend available (neither VLC nor pygame) - "
+                "playback and volume control are disabled"
+            )
 
     @property
     def is_playing(self) -> bool:
@@ -642,7 +649,8 @@ class ServerState:
                     "active_wake_words": self.preferences.active_wake_words,
                     "thinking_sound": self.preferences.thinking_sound,
                     "volume": self.preferences.volume,
-                    "voice_input_hotkey": self.preferences.voice_input_hotkey
+                    "voice_input_hotkey": self.preferences.voice_input_hotkey,
+                    "mic_device": self.preferences.mic_device
                 }, f, ensure_ascii=False, indent=4)
         except Exception as e:
             logger.error(f"Failed to save preferences: {e}")
@@ -660,6 +668,7 @@ class ServerState:
                 volume = data.get("volume")
                 self.preferences.volume = float(volume) if volume is not None else None
                 self.preferences.voice_input_hotkey = data.get("voice_input_hotkey", "")
+                self.preferences.mic_device = data.get("mic_device", "")
                 
         except Exception as e:
             logger.error(f"Failed to load preferences: {e}")

--- a/src/i18n.py
+++ b/src/i18n.py
@@ -64,6 +64,8 @@ class I18n:
                 # 设置
                 'settings_language': '语言',
                 'settings_audio_device': '音频设备',
+                'settings_microphone': '麦克风',
+                'settings_default_device': '系统默认',
                 'settings_wake_word_model': '唤醒词模型',
                 'settings_log_level': '日志级别',
 
@@ -168,6 +170,8 @@ class I18n:
                 # Settings
                 'settings_language': 'Language',
                 'settings_audio_device': 'Audio Device',
+                'settings_microphone': 'Microphone',
+                'settings_default_device': 'System Default',
                 'settings_wake_word_model': 'Wake Word Model',
                 'settings_log_level': 'Log Level',
 

--- a/src/main.py
+++ b/src/main.py
@@ -179,6 +179,7 @@ class HomeAssistantWindows:
         self._stop_word_detector = None
         self._wake_word_callback = None
         self._audio_recorder: AudioRecorder = None
+        self._audio_callback = None
         self._wake_word_listening = False
         self._event_loop = None  # Event loop reference for callbacks
         self._mdns_refresh_task: asyncio.Task | None = None
@@ -238,6 +239,22 @@ class HomeAssistantWindows:
         # Run server in background
         asyncio.create_task(self.api_server.serve_forever())
 
+    def _set_microphone(self, device_name: str) -> None:
+        """Switch the recording microphone ("" = system default) and persist it."""
+        state = self.api_server.state
+        state.preferences.mic_device = device_name
+        state.save_preferences()
+
+        if not self._audio_recorder:
+            return
+
+        was_recording = self._audio_recorder.is_recording
+        self._audio_recorder.stop_recording()
+        self._audio_recorder.device = device_name or None
+        if was_recording:
+            self._audio_recorder.start_recording(audio_callback=self._audio_callback)
+        logger.info(f"🎤 Microphone set to: {device_name or 'system default'}")
+
     async def _register_mdns_service(self):
         """Register mDNS service broadcast"""
         logger.info("Registering mDNS service broadcast...")
@@ -261,7 +278,7 @@ class HomeAssistantWindows:
         # Set up tray callbacks
         from src import __version__
         self.tray.set_version(__version__)
-        self.tray.set_callbacks(on_quit=self._request_quit)
+        self.tray.set_callbacks(on_quit=self._request_quit, on_mic_change=self._set_microphone)
 
         # Start system tray icon
         display_name = device_info.name if device_info.name else self.device_name
@@ -353,8 +370,10 @@ class HomeAssistantWindows:
             for detector in self._wake_word_detectors.values():
                 detector.on_wake_word(on_wake_word)
 
-            # Initialize audio recorder
-            self._audio_recorder = AudioRecorder()
+            # Initialize audio recorder (empty preference = system default)
+            self._audio_recorder = AudioRecorder(
+                self.api_server.state.preferences.mic_device or None
+            )
 
             # Audio callback for wake word detection
             def on_audio_chunk(audio_data: bytes):
@@ -384,6 +403,7 @@ class HomeAssistantWindows:
 
             # Start recording
             self._wake_word_listening = True
+            self._audio_callback = on_audio_chunk
             self._audio_recorder.start_recording(audio_callback=on_audio_chunk)
 
             wake_phrases = [det.wake_word_phrase for det in self._wake_word_detectors.values()]

--- a/src/ui/system_tray_icon.py
+++ b/src/ui/system_tray_icon.py
@@ -88,6 +88,7 @@ class SystemTrayIcon:
         self._current_phase = self.PHASE_IDLE
         self._status_info = {'name': 'Unknown', 'ip': 'Unknown', 'port': 'Unknown'}
         self._on_quit: Optional[Callable] = None
+        self._on_mic_change: Optional[Callable] = None
         self._version = "0.0.0"
 
     def create_icon_image(self, width: int = 64, height: int = 64) -> Image.Image:
@@ -165,6 +166,34 @@ class SystemTrayIcon:
         self._running = False
         icon.stop()
 
+    def _current_mic(self) -> str:
+        if self._state is None:
+            return ""
+        return getattr(self._state.preferences, 'mic_device', "")
+
+    def _select_mic(self, device_name: str) -> None:
+        logger.info(f"Microphone menu selected: {device_name or 'system default'}")
+        if self._on_mic_change:
+            try:
+                self._on_mic_change(device_name)
+            except Exception as e:
+                logger.error(f"Failed to switch microphone: {e}")
+
+    def _mic_menu_items(self):
+        """Build the microphone radio list (rebuilt each time the menu opens)."""
+        from src.voice.audio_recorder import AudioRecorder
+
+        def item_for(name: str):
+            return pystray.MenuItem(
+                name or _i18n.t('settings_default_device'),
+                lambda icon, item: self._select_mic(name),
+                checked=lambda item: self._current_mic() == name,
+                radio=True,
+            )
+
+        for name in [""] + AudioRecorder.list_microphones():
+            yield item_for(name)
+
     def _on_about_menu(self, icon, item) -> None:
         logger.info("About menu clicked")
         show_about_dialog(self._version)
@@ -194,6 +223,7 @@ class SystemTrayIcon:
             icon=self.create_icon_image(),
             menu=pystray.Menu(
                 pystray.MenuItem(_i18n.t('status_running'), self._on_show_status),
+                pystray.MenuItem(_i18n.t('settings_microphone'), pystray.Menu(self._mic_menu_items)),
                 pystray.MenuItem('About', self._on_about_menu),
                 pystray.MenuItem(_i18n.t('quit'), self._on_quit_menu),
             )
@@ -249,8 +279,10 @@ class SystemTrayIcon:
                 f"{_i18n.t('ip_label')}: {self._status_info['ip']}:{self._status_info['port']}"
             )
 
-    def set_callbacks(self, on_quit: Callable = None) -> None:
+    def set_callbacks(self, on_quit: Callable = None, on_mic_change: Callable = None) -> None:
         self._on_quit = on_quit
+        if on_mic_change is not None:
+            self._on_mic_change = on_mic_change
 
     def stop(self) -> None:
         if self.icon and self._running:

--- a/src/voice/audio_recorder.py
+++ b/src/voice/audio_recorder.py
@@ -35,12 +35,38 @@ class AudioRecorder:
 
     @staticmethod
     def list_microphones() -> list[str]:
+        """Input device names, deduplicated and preferring WASAPI.
+
+        Every mic shows up once per host API (MME/DirectSound/WASAPI/WDM-KS),
+        and MME truncates names to 31 chars, so listing everything is unusable.
+        """
         try:
             devices = sd.query_devices()
-            return [d["name"] for d in devices if d["max_input_channels"] > 0]
         except Exception as e:
             logger.error(f"Failed to get microphone list: {e}")
             return []
+
+        wasapi = None
+        try:
+            for i, api in enumerate(sd.query_hostapis()):
+                if "WASAPI" in api["name"]:
+                    wasapi = i
+                    break
+        except Exception:
+            pass
+
+        def collect(hostapi: Optional[int]) -> list[str]:
+            names: list[str] = []
+            for d in devices:
+                if d["max_input_channels"] <= 0:
+                    continue
+                if hostapi is not None and d["hostapi"] != hostapi:
+                    continue
+                if d["name"] not in names:
+                    names.append(d["name"])
+            return names
+
+        return collect(wasapi) or collect(None)
 
     def _resolve_device(self) -> Optional[int]:
         if self.device is None:

--- a/tests/test_audio_recording.py
+++ b/tests/test_audio_recording.py
@@ -309,6 +309,23 @@ class TestAudioRecordingEdgeCases:
         
         assert isinstance(mics, list), "list_microphones should return a list"
 
+    def test_list_microphones_has_no_duplicates(self):
+        """
+        list_microphones() SHALL NOT repeat a device name across host APIs.
+        """
+        mics = AudioRecorder.list_microphones()
+
+        assert len(mics) == len(set(mics)), f"Duplicate microphone names: {mics}"
+
+    def test_listed_microphone_resolves_to_an_input_device(self):
+        """
+        Every listed microphone name SHALL resolve to a real input device index.
+        """
+        for name in AudioRecorder.list_microphones():
+            device_id = AudioRecorder(name)._resolve_device()
+
+            assert device_id is not None, f"Listed mic did not resolve: {name}"
+
     def test_zero_duration_silence(self):
         """
         Zero duration silence SHALL produce empty bytes.


### PR DESCRIPTION
## What

Lets users pick which microphone the voice assistant records from. `AudioRecorder` already accepted a `device` argument, but no caller ever passed one, so it always used the system default.

Right-click tray → **Microphone** → pick one. Saved to `preferences.json`, applied immediately.

## Changes

- `Preferences.mic_device`, persisted (`""` = system default)
- Tray radio submenu, rebuilt each time it opens so hotplugged mics appear
- `_set_microphone()` stops and restarts the recorder on the new device — no app restart
- `list_microphones()` dedupes and prefers WASAPI. It previously returned every device on every host API — 23 entries on my machine for 4 physical mics, with MME names truncated at 31 chars
- Removed `ESPHomeProtocol._get_audio_recorder()` — dead, never called, and it would have ignored the setting
- Log an error when neither VLC nor pygame is available
- Tests: no duplicate names, every listed name resolves to a real input index

New tray strings added to both `zh_CN` and `en_US`.

## Note on Chinese text

Comments and log messages in the new code are English only. No existing Chinese strings were removed. Happy to translate the additions if you'd prefer consistency.
